### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/peterfortuin/n8n-nodes-bunq/security/code-scanning/1](https://github.com/peterfortuin/n8n-nodes-bunq/security/code-scanning/1)

In general, this is fixed by explicitly specifying a `permissions` block in the workflow (either at the top level or per job) that grants only the scopes required. For a simple CI job that only checks out code, installs dependencies, and runs lint/build, read access to repository contents and (optionally) packages is sufficient.

The minimal, non‑breaking change here is to add a root-level `permissions` block right after the `name: CI` line, setting `contents: read`. This will apply to all jobs in the workflow (including `build`) that do not define their own `permissions`. No other code or steps need to change, and no additional imports or actions are required. If your npm scripts ever need more privileges, those can later be added explicitly (e.g., `pull-requests: write`) to this block or per-job, but based on the given snippet only `contents: read` is needed.

Concretely: edit `.github/workflows/ci.yml`, insert:

```yaml
permissions:
  contents: read
```

between line 1 (`name: CI`) and line 3 (`on:`). This documents and enforces least-privilege token permissions for the workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
