### PR TITLE
fix: safe error message extraction in all catch blocks

### DIFF
--- a/nodes/BunqSession/BunqSession.node.ts
+++ b/nodes/BunqSession/BunqSession.node.ts
@@ -7,6 +7,7 @@ import {
 import {
   ensureBunqSession,
 } from '../../utils/bunqApiHelpers';
+import { getErrorMessage } from '../../utils/errorHelpers';
 
 // eslint-disable-next-line @n8n/community-nodes/node-usable-as-tool
 export class BunqSession implements INodeType {
@@ -73,7 +74,7 @@ export class BunqSession implements INodeType {
         // Return error data for all items if continueOnFail is enabled
         const returnData: INodeExecutionData[] = items.map((_, i) => ({
           json: {
-            error: error.message,
+            error: getErrorMessage(error),
           },
           pairedItem: {
             item: i,

--- a/nodes/BunqTrigger/BunqTrigger.node.ts
+++ b/nodes/BunqTrigger/BunqTrigger.node.ts
@@ -10,13 +10,7 @@ import {
 	ensureBunqSession,
 } from '../../utils/bunqApiHelpers';
 import { BunqHttpClient } from '../../utils/BunqHttpClient';
-
-/**
- * Extract error message from unknown error type
- */
-function getErrorMessage(error: unknown): string {
-	return error instanceof Error ? error.message : 'Unknown error';
-}
+import { getErrorMessage } from '../../utils/errorHelpers';
 
 // eslint-disable-next-line @n8n/community-nodes/node-usable-as-tool
 export class BunqTrigger implements INodeType {

--- a/nodes/CreatePayment/CreatePayment.node.ts
+++ b/nodes/CreatePayment/CreatePayment.node.ts
@@ -9,6 +9,7 @@ import {
   ensureBunqSession,
 } from '../../utils/bunqApiHelpers';
 import { BunqHttpClient } from '../../utils/BunqHttpClient';
+import { getErrorMessage } from '../../utils/errorHelpers';
 
 /**
  * Interface for payment counterparty (recipient)
@@ -357,7 +358,7 @@ export class CreatePayment implements INodeType {
           returnData.push({
             json: {
               success: false,
-              error: error.message,
+              error: getErrorMessage(error),
             },
             pairedItem: {
               item: itemIndex,

--- a/nodes/MonetaryAccounts/MonetaryAccounts.node.ts
+++ b/nodes/MonetaryAccounts/MonetaryAccounts.node.ts
@@ -9,6 +9,7 @@ import {
   ensureBunqSession,
 } from '../../utils/bunqApiHelpers';
 import { BunqHttpClient } from '../../utils/BunqHttpClient';
+import { getErrorMessage } from '../../utils/errorHelpers';
 
 // eslint-disable-next-line @n8n/community-nodes/node-usable-as-tool
 export class MonetaryAccounts implements INodeType {
@@ -150,7 +151,7 @@ export class MonetaryAccounts implements INodeType {
         // Return error data for all items if continueOnFail is enabled
         const returnData: INodeExecutionData[] = items.map((_, i) => ({
           json: {
-            error: error.message,
+            error: getErrorMessage(error),
           },
           pairedItem: {
             item: i,

--- a/nodes/Payments/Payments.node.ts
+++ b/nodes/Payments/Payments.node.ts
@@ -9,6 +9,7 @@ import {
   ensureBunqSession,
 } from '../../utils/bunqApiHelpers';
 import { BunqHttpClient } from '../../utils/BunqHttpClient';
+import { getErrorMessage } from '../../utils/errorHelpers';
 
 // eslint-disable-next-line @n8n/community-nodes/node-usable-as-tool
 export class Payments implements INodeType {
@@ -206,7 +207,7 @@ export class Payments implements INodeType {
         if (this.continueOnFail()) {
           returnData.push({
             json: {
-              error: error.message,
+              error: getErrorMessage(error),
             },
             pairedItem: {
               item: itemIndex,

--- a/utils/errorHelpers.ts
+++ b/utils/errorHelpers.ts
@@ -4,5 +4,22 @@
  * access to `.message` is a type error without a guard.
  */
 export function getErrorMessage(error: unknown): string {
-	return error instanceof Error ? error.message : 'Unknown error';
+	if (error instanceof Error) {
+		return error.message;
+	}
+
+	if (typeof error === 'string') {
+		return error;
+	}
+
+	if (
+		typeof error === 'object' &&
+		error !== null &&
+		'message' in error &&
+		typeof error.message === 'string'
+	) {
+		return error.message;
+	}
+
+	return 'Unknown error';
 }

--- a/utils/errorHelpers.ts
+++ b/utils/errorHelpers.ts
@@ -1,0 +1,8 @@
+/**
+ * Safely extract a human-readable message from an unknown catch-clause value.
+ * TypeScript 4.4+ (strict mode) types catch variables as `unknown`, so direct
+ * access to `.message` is a type error without a guard.
+ */
+export function getErrorMessage(error: unknown): string {
+	return error instanceof Error ? error.message : 'Unknown error';
+}


### PR DESCRIPTION
## Summary

TypeScript strict mode (`useUnknownInCatchVariables`, part of `"strict": true` since TS 4.4) types catch-clause variables as `unknown`. Directly accessing `.message` on an `unknown` value is a type error.

`BunqTrigger` had a correct local `getErrorMessage` guard, but every other node accessed `error.message` without any narrowing.

### Changes
- Add `utils/errorHelpers.ts` with a shared `getErrorMessage(error: unknown): string` helper
- Remove the duplicate local definition from `BunqTrigger.node.ts`
- Import and use the shared helper in: `BunqSession`, `Payments`, `MonetaryAccounts`, `CreatePayment`, `BunqTrigger`

## Test plan
- [x] `npx tsc --noEmit` passes with no errors
- [x] Each node's `continueOnFail` path returns a meaningful error string instead of `undefined`

https://claude.ai/code/session_01T5T9x8AHu72hokuA2ti4jn