### PR TITLE
fix(rateLimit): remove redundant inline comment from GET windowMs

### DIFF
--- a/utils/rateLimit.ts
+++ b/utils/rateLimit.ts
@@ -13,7 +13,7 @@ type BunqApiContext = IExecuteFunctions | IHookFunctions;
 export const RATE_LIMITS = {
 	GET: {
 		maxRequests: 3,
-		windowMs: 4000, // 3 seconds
+		windowMs: 4000, // 4 seconds
 	},
 	POST: {
 		maxRequests: 5,

--- a/utils/rateLimit.ts
+++ b/utils/rateLimit.ts
@@ -13,7 +13,7 @@ type BunqApiContext = IExecuteFunctions | IHookFunctions;
 export const RATE_LIMITS = {
 	GET: {
 		maxRequests: 3,
-		windowMs: 4000, // 4 seconds
+		windowMs: 4000,
 	},
 	POST: {
 		maxRequests: 5,


### PR DESCRIPTION
`RATE_LIMITS.GET.windowMs` had an inline comment (`// 3 seconds`, later corrected to `// 4 seconds`) that adds no information beyond what the literal `4000` already conveys. Removed it.