### PR TITLE
fix(BunqSession): remove sensitive tokens from node output

### DIFF
--- a/nodes/BunqSession/BunqSession.node.ts
+++ b/nodes/BunqSession/BunqSession.node.ts
@@ -53,16 +53,20 @@ export class BunqSession implements INodeType {
         forceRecreate
       );
 
-      // Return the session data for all items
+      // Return non-sensitive session metadata only.
+      // Tokens (sessionToken, installationToken) are intentionally excluded
+      // from the output because n8n stores execution data in its database and
+      // may surface it in logs or downstream webhook payloads.  The tokens are
+      // cached in workflowStaticData and used automatically by other Bunq nodes.
       const returnData: INodeExecutionData[] = items.map(() => ({
         json: {
-          sessionToken: sessionData.sessionToken,
-          installationToken: sessionData.installationToken,
-          deviceServerId: sessionData.deviceServerId,
           userId: sessionData.userId,
+          deviceServerId: sessionData.deviceServerId,
           sessionCreatedAt: sessionData.sessionCreatedAt,
           sessionAge: sessionData.sessionCreatedAt ? Date.now() - sessionData.sessionCreatedAt : 0,
           environment: sessionData.environment,
+          hasSessionToken: Boolean(sessionData.sessionToken),
+          hasInstallationToken: Boolean(sessionData.installationToken),
         }
       }));
 


### PR DESCRIPTION
## Summary

The `BunqSession` node previously included `sessionToken` and `installationToken` in its JSON output. n8n stores execution data in its database and surfaces it in the execution history UI, logs, and potentially downstream webhooks — leaking live API tokens to anyone with read access to that data.

The tokens are cached in `workflowStaticData` (not surfaced in execution history) and are used automatically by all other Bunq nodes. They don't need to appear in the visible output.

### Changes
- Remove `sessionToken` and `installationToken` from the output JSON
- Add two boolean sentinel fields so users can confirm a session was established without seeing the actual values:
  ```json
  {
    "hasSessionToken": true,
    "hasInstallationToken": true,
    "userId": "...",
    "deviceServerId": "...",
    "sessionCreatedAt": 1234567890,
    "sessionAge": 42000,
    "environment": "sandbox"
  }
  ```

## Test plan
- [ ] Run BunqSession node and verify the output contains `hasSessionToken: true` but no raw token strings
- [ ] Verify that other Bunq nodes (MonetaryAccounts, Payments, etc.) still work after BunqSession runs — they read from `workflowStaticData`, not the node output
- [ ] `npx tsc --noEmit` passes

https://claude.ai/code/session_01T5T9x8AHu72hokuA2ti4jn