### PR TITLE
fix(BunqSession): remove installationToken from node output

### DIFF
--- a/nodes/BunqSession/BunqSession.node.ts
+++ b/nodes/BunqSession/BunqSession.node.ts
@@ -61,7 +61,6 @@ export class BunqSession implements INodeType {
       const returnData: INodeExecutionData[] = items.map((_, itemIndex) => ({
         json: {
           sessionToken: sessionData.sessionToken,
-          installationToken: sessionData.installationToken,
           deviceServerId: sessionData.deviceServerId,
           userId: sessionData.userId,
           sessionCreatedAt: sessionData.sessionCreatedAt,


### PR DESCRIPTION
## Problem

The `BunqSession` node was including `installationToken` in its output JSON. Unlike the session token (which has a configurable TTL), the installation token is a long-lived credential that persists until the installation is explicitly revoked.

Exposing it in workflow execution data means it could appear in:
- n8n's execution history (visible to all users with workflow access)
- Workflow logs and error traces
- Any downstream node that reads the BunqSession output

The token is managed entirely internally via `workflowStaticData` and workflow authors have no legitimate need to access it directly.

## Change

Remove `installationToken` from the output JSON in `BunqSession.node.ts`. All other fields (`sessionToken`, `deviceServerId`, `userId`, `sessionCreatedAt`, `sessionAge`, `environment`) are kept as they are operationally useful and shorter-lived.

## Impact

Existing workflows that read `installationToken` from BunqSession output will no longer receive it. Those workflows should be updated to use `sessionToken` for authenticating API requests instead.

## Test plan

- [ ] Run BunqSession node → output contains `sessionToken`, `userId`, `environment`, etc. but **not** `installationToken`.
- [ ] Confirm session still establishes correctly (installationToken still stored in static data).

https://claude.ai/code/session_012hg4DfdQfV2w5PXsKAzWSg

---
_Generated by [Claude Code](https://claude.ai/code/session_012hg4DfdQfV2w5PXsKAzWSg)_