### PR TITLE
refactor(BunqHttpClient): remove unused handleExecuteError method

### DIFF
--- a/utils/BunqHttpClient.ts
+++ b/utils/BunqHttpClient.ts
@@ -1,7 +1,6 @@
 import {
 	IExecuteFunctions,
 	IHookFunctions,
-	INodeExecutionData,
 	IHttpRequestOptions,
 	NodeApiError,
 } from 'n8n-workflow';
@@ -240,32 +239,4 @@ export class BunqHttpClient {
 		}
 	}
 
-	/**
-	 * Handle errors in execute context with continueOnFail support
-	 * This method should be used in node execute() methods to handle errors appropriately
-	 */
-	handleExecuteError(
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		error: any,
-		items: INodeExecutionData[],
-		continueOnFail: boolean,
-	): INodeExecutionData[] | never {
-		const errorMessage = error instanceof Error ? error.message : 'Unknown error';
-		const errorResponse = error?.response;
-
-		if (continueOnFail) {
-			const returnData: INodeExecutionData[] = items.map((_, i) => ({
-				json: {
-					error: errorMessage,
-					statusCode: errorResponse?.status,
-					responseData: errorResponse?.data,
-				},
-				pairedItem: {
-					item: i,
-				},
-			}));
-			return returnData;
-		}
-		throw error;
-	}
 }


### PR DESCRIPTION
## Problem

`BunqHttpClient.handleExecuteError()` was defined but never called. All six nodes (`BunqSession`, `SignRequest`, `BunqTrigger`, `MonetaryAccounts`, `Payments`, `CreatePayment`) implement identical inline `continueOnFail` error handling rather than delegating to this method.

The dead method carried two additional code smells:
- An `// eslint-disable-next-line @typescript-eslint/no-explicit-any` suppression for its `error: any` parameter.
- Kept the `INodeExecutionData` import in `BunqHttpClient.ts` even though the class itself never constructs execution data.

## Changes

- Remove `handleExecuteError` from `BunqHttpClient`.
- Remove the now-unused `INodeExecutionData` import.

## Test plan

- [x] All nodes execute normally (no change in runtime behaviour).
- [x] TypeScript compilation succeeds (no `noUnusedLocals` errors).

https://claude.ai/code/session_012hg4DfdQfV2w5PXsKAzWSg

---
_Generated by [Claude Code](https://claude.ai/code/session_012hg4DfdQfV2w5PXsKAzWSg)_