### PR TITLE
fix(CreatePayment): make currency configurable instead of hardcoding EUR

### DIFF
--- a/nodes/CreatePayment/CreatePayment.node.ts
+++ b/nodes/CreatePayment/CreatePayment.node.ts
@@ -165,7 +165,16 @@ export class CreatePayment implements INodeType {
         default: '',
         required: true,
         placeholder: '10.00',
-        description: 'The amount to transfer in EUR (e.g., "10.00")',
+        description: 'The amount to transfer (e.g., "10.00")',
+      },
+      {
+        displayName: 'Currency',
+        name: 'currency',
+        type: 'string',
+        default: 'EUR',
+        required: true,
+        placeholder: 'EUR',
+        description: 'ISO 4217 currency code (e.g., EUR, USD). Must match the currency of the source monetary account.',
       },
       {
         displayName: 'Description',
@@ -194,6 +203,7 @@ export class CreatePayment implements INodeType {
         const paymentType = this.getNodeParameter('paymentType', itemIndex) as string;
         const recipientType = this.getNodeParameter('recipientType', itemIndex) as string;
         const amount = this.getNodeParameter('amount', itemIndex) as string;
+        const currency = (this.getNodeParameter('currency', itemIndex) as string).trim().toUpperCase();
         const description = this.getNodeParameter('description', itemIndex) as string;
 
         // Validate amount format
@@ -202,6 +212,14 @@ export class CreatePayment implements INodeType {
           throw new NodeOperationError(
             this.getNode(),
             `Invalid amount format: "${amount}". Please use a number with up to 2 decimal places (e.g., "10.00" or "10")`,
+          );
+        }
+
+        // Validate currency (ISO 4217: 3 uppercase letters)
+        if (!/^[A-Z]{3}$/.test(currency)) {
+          throw new NodeOperationError(
+            this.getNode(),
+            `Invalid currency code: "${currency}". Please use a 3-letter ISO 4217 code (e.g., "EUR").`,
           );
         }
 
@@ -288,7 +306,7 @@ export class CreatePayment implements INodeType {
         const buildActualRequestBody = () => JSON.stringify({
           amount: {
             value: amount,
-            currency: 'EUR',
+            currency,
           },
           counterparty_alias: counterparty,
           description: description,
@@ -300,7 +318,7 @@ export class CreatePayment implements INodeType {
             {
               amount: {
                 value: amount,
-                currency: 'EUR',
+                currency,
               },
               counterparty_alias: counterparty,
               description: description,


### PR DESCRIPTION
## Problem

Both the actual-payment and draft-payment request bodies in `CreatePayment.node.ts` had the currency hard-coded to `'EUR'`:

```typescript
amount: {
  value: amount,
  currency: 'EUR',   // ← always EUR, no way to override
},
```

This meant the node could not be used with non-EUR monetary accounts (e.g., USD, GBP, CHF accounts).

## Changes

- **Add `Currency` field** — required string input, default `'EUR'`, placed after the Amount field. Includes a description noting it must match the source account's currency.
- **Normalise input** — trim whitespace and uppercase the value so minor formatting differences don't cause Bunq API errors.
- **Validate format** — check against ISO 4217 pattern (`/^[A-Z]{3}$/`) and throw a `NodeOperationError` early with a clear message.
- **Thread through request bodies** — replace both `'EUR'` literals in `buildActualRequestBody()` and `buildDraftRequestBody()` with the `currency` variable.
- **Update Amount description** — remove the EUR-specific wording now that the currency is configurable.

## Backwards compatibility

Existing nodes will show `EUR` as the default, so workflows that previously relied on the implicit EUR behaviour are unaffected.

## Test plan

- [ ] Create an actual payment with `currency = EUR` → succeeds as before.
- [ ] Create a draft payment with `currency = EUR` → succeeds as before.
- [ ] Set `currency = usd` (lowercase) → normalised to `USD`, payment created.
- [ ] Set `currency = EU` (2 letters) → `NodeOperationError` thrown before any API call.
- [ ] Set `currency = EURO` (4 letters) → `NodeOperationError` thrown before any API call.

https://claude.ai/code/session_012hg4DfdQfV2w5PXsKAzWSg

---
_Generated by [Claude Code](https://claude.ai/code/session_012hg4DfdQfV2w5PXsKAzWSg)_